### PR TITLE
Use specific lodash modules to reduce package size

### DIFF
--- a/lib/rules/default-export-match-filename.js
+++ b/lib/rules/default-export-match-filename.js
@@ -2,7 +2,10 @@
  * @author Stefan Lau
  */
 
-const { camelCase, upperFirst, kebabCase, snakeCase } = require('lodash');
+const camelCase = require('lodash.camelcase');
+const upperFirst = require('lodash.upperfirst');
+const kebabCase = require('lodash.kebabcase');
+const snakeCase = require('lodash.snakecase');
 
 var path = require('path'),
     parseFilename = require('../common/parseFilename'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
             "version": "0.0.4",
             "license": "MIT",
             "dependencies": {
-                "lodash": "^4.17.21"
+                "lodash.camelcase": "^4.3.0",
+                "lodash.kebabcase": "^4.1.1",
+                "lodash.snakecase": "^4.1.1",
+                "lodash.upperfirst": "^4.3.1"
             },
             "devDependencies": {
                 "eslint": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
         "test": "mocha tests --recursive"
     },
     "dependencies": {
-        "lodash": "^4.17.21"
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.upperfirst": "^4.3.1"
     },
     "devDependencies": {
         "eslint": "^7.1.0",


### PR DESCRIPTION
Since only four methods(`camelCase`, `upperFirst`, `kebabCase`, `snakeCase`) are currently being used within the plugin, I decided that it would be better to install only the individual modules needed than to install the entire large module.

Below is the result of checking the size of the dependency.
There may be exceptions in the actual situation or environment, but basically, the difference in size remains unchanged.

**Before**
<img width="550" alt="lodash" src="https://user-images.githubusercontent.com/23455736/128443355-d165a930-bc22-4910-bc83-0a3a6a7bb1d2.png">

**After**
<img width="543" alt="modules" src="https://user-images.githubusercontent.com/23455736/128443390-20e6355d-c797-4b21-a61f-de7908525512.png">

Thanks for this good project!