### PR TITLE
gracefully support a lack of resolver settings

### DIFF
--- a/lib/common/resolve.js
+++ b/lib/common/resolve.js
@@ -141,23 +141,27 @@ function fullResolve(modulePath, sourceFile, settings) {
         }
     }
 
-    const configResolvers = settings['import/resolver'] || {
-        node: settings['import/resolve'],
-    }; // backward compatibility
 
-    const resolvers = resolverReducer(configResolvers, new Map());
+    const configResolvers = settings['import/resolver'] ? settings['import/resolver'] : 
+                            settings['import/resolve'] ?  {
+                                node: settings['import/resolve'], // backward compatibility
+                            } : null;
 
-    for (const pair of resolvers) {
-        const name = pair[0];
-        const config = pair[1];
-        const resolver = requireResolver(name, sourceFile);
-        const resolved = withResolver(resolver, config);
+    if(configResolvers) {
 
-        if (!resolved.found) continue;
+        for (const pair of resolvers) {
+            const name = pair[0];
+            const config = pair[1];
+            const resolver = requireResolver(name, sourceFile);
+            const resolved = withResolver(resolver, config);
 
-        // else, counts
-        cache(resolved.path);
-        return resolved;
+            if (!resolved.found) continue;
+
+            // else, counts
+            cache(resolved.path);
+            return resolved;
+        }
+
     }
 
     // failed


### PR DESCRIPTION
This is to support PhET simulation integration of the `default-import-match-filename` rule. See https://github.com/minseoksuh/eslint-plugin-consistent-default-export-name/issues/7